### PR TITLE
システム一覧：ゲームシステムIDを載せる

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -198,11 +198,20 @@ article {
     th, td {
       padding: 0.3rem 0.5rem;
       border: 1px solid #ccc;
+      text-align: left;
+      word-break: break-all;
     }
 
     th {
-      text-align: left;
       font-weight: 600;
+    }
+
+    .system-name {
+      width: 60%;
+    }
+
+    .system-id {
+      width: 40%;
     }
 
     tbody {

--- a/css/style.scss
+++ b/css/style.scss
@@ -190,6 +190,27 @@ article {
   section.summary p {
     font-size: 1.3rem;
   }
+
+  table.system-list {
+    width: 100%;
+    border-collapse: collapse;
+
+    th, td {
+      padding: 0.3rem 0.5rem;
+      border: 1px solid #ccc;
+    }
+
+    th {
+      text-align: left;
+      font-weight: 600;
+    }
+
+    tbody {
+      tr:nth-child(odd) {
+        background-color: #f1f1f1;
+      }
+    }
+  }
 }
 
 .maintainer {

--- a/systems.html
+++ b/systems.html
@@ -17,15 +17,15 @@ layout: default
   <table class="system-list">
     <thead>
       <tr>
-        <th>名前</th>
-        <th>ID</th>
+        <th class="system-name">名前</th>
+        <th class="system-id">ID</th>
       </tr>
     </thead>
     <tbody>
     {% for system in category[1] %}
       <tr>
-        <td>{{ system.name }}</td>
-        <td>{{ system.system }}</td>
+        <td class="system-name">{{ system.name }}</td>
+        <td class="system-id">{{ system.system }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/systems.html
+++ b/systems.html
@@ -14,10 +14,21 @@ layout: default
 
   {% for category in site.data.systems.systems %}
   <h2 id="{{ category[0] }}">{{ category[0] }}</h2>
-  <ul>
+  <table class="system-list">
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th>ID</th>
+      </tr>
+    </thead>
+    <tbody>
     {% for system in category[1] %}
-    <li>{{ system.name }}</li>
+      <tr>
+        <td>{{ system.name }}</td>
+        <td>{{ system.system }}</td>
+      </tr>
     {% endfor %}
-  </ul>
+    </tbody>
+  </table>
   {% endfor %}
 </article>


### PR DESCRIPTION
システム一覧に表の形でゲームシステムIDを載せてみました。コマンド入力型のボット（bcdice-irc、discord-bcdicebot等）からゲームシステムを切り替える場合にはIDの入力が必要なので、それを探しやすくする目的です。

![bcdice_org-systems](https://user-images.githubusercontent.com/2551173/116651564-719e1d00-a9be-11eb-9346-903fdfd16bca.png)
